### PR TITLE
Fix: deprecated versions of github actions

### DIFF
--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -21,7 +21,7 @@ jobs:
           docker build -t $IMAGE_NAME .
           docker save $IMAGE_NAME | gzip > telegram_bot_image.tar.gz
       - name: Upload Docker Image as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: telegram_bot_image
           path: telegram_bot_image.tar.gz
@@ -35,13 +35,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download Docker Image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: telegram_bot_image
           path: telegram_bot_image.tar.gz
 
       - name: copy files to target server via scp
-        uses: appleboy/scp-action@v0.1.3
+        uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}

--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -46,7 +46,9 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
-          source: "./docker-compose.yml"
+          source: |
+            ./docker-compose.yml
+            telegram_bot_image.tar.gz
           target: "~/telegram_bot/"
 
       - name: Deploy to Server via SSH


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Обновления**
	- Обновлены версии GitHub Actions для загрузки и скачивания артефактов с `v3` до `v4`.
	- Обновлена версия действия `appleboy/scp-action` с `v0.1.3` до `v0.1.7`.
	- Улучшен формат указания исходных файлов при копировании на сервер.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->